### PR TITLE
Allow content-type to simply contain application/json

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -56,7 +56,7 @@ class Request implements RequestInterface, Form\RequestInterface
         $params['GET'] =& $_GET;
         $params['POST'] =& $_POST;
         if ($this->getMethod() === 'POST'
-            && $this->getHeader('CONTENT_TYPE') === 'application/json'
+            && strpos($this->getHeader('CONTENT_TYPE'), 'application/json') === 0
         ) {
             $params['JSON'] = json_decode(file_get_contents('php://input'), true);
         }


### PR DESCRIPTION
The content type coming from Postmark is `application/json;
charset=utf-8`, rather than just simply `application/json`, so the JSON
is not being loaded.

Required by kelvineducation/pulse#249