### PR TITLE
Increase db connection timeout from 2 seconds to 10 seconds

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -310,7 +310,7 @@ SQL;
      * @param int $conn_timeout
      * @return string
      */
-    private static function pgConnStr(string $url, int $conn_timeout = 2): string
+    private static function pgConnStr(string $url, int $conn_timeout = 10): string
     {
         $host = parse_url($url, PHP_URL_HOST);
         $port = parse_url($url, PHP_URL_PORT) ?: 5432;


### PR DESCRIPTION
We will make this optional in the future, but for now 2 seconds is too
short.