### PR TITLE
Fix issues with exponents not being quoted properly

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -222,7 +222,7 @@ SQL;
             return ($val ? 'TRUE' : 'FALSE');
         }
 
-        if (is_numeric($val)) {
+        if (is_int($val)) {
             return "{$val}";
         }
 


### PR DESCRIPTION
is_numeric('1e5') will return true. This is bad for things like guids
that are not meant to be a number. Instead we will choose to look for
integers via is_int()