### PR TITLE
Remove need for is_numeric check

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -222,10 +222,6 @@ SQL;
             return ($val ? 'TRUE' : 'FALSE');
         }
 
-        if (is_numeric($val)) {
-            return "{$val}";
-        }
-
         if (is_object($val) && get_class($val) === DbExpr::class) {
             return "{$val}";
         }


### PR DESCRIPTION
This is_numeric check will cause chaos with strings like "22e312" which
we do for random short codes for example.

Instead let pg_escape_literal() do all the work for us