### PR TITLE
Selection OptGroups

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -60,7 +60,7 @@ class Form
         return $field;
     }
 
-    public function addSelect(string $name, array $options = [], array $selected = [], string $label = '')
+    public function addSelect(string $name, array $options = [], array $selected = [], string $label = '', bool $use_opt_group = false, string $default_option = '')
     {
         $field = new Field($name, 'select', $label);
         $field->setAttribute('class', 'form-control');
@@ -70,6 +70,10 @@ class Form
         }
         $field->setSelected($selected);
         $field->setOptions($options);
+        $field->setDefaultOption($default_option);
+        if ($use_opt_group) {
+            $field->setOptGroups();
+        }
         $this->addField($field);
         return $field;
     }


### PR DESCRIPTION
Added opt group parameters for selection method to allow for opt group functionality including default value of 0.

## What did you change?

🚀 New Feature

Added the ability to add optgroups to drop down selection fields.

## Why did you change it?

In instances in which the selection has a lot of options, adding an opt group provides a nice way to label and organize options for users.

## Screenshots

**After:**
![D82D8AE0-824E-4F5F-8049-2093CB866BE6](https://github.com/user-attachments/assets/59c0cb04-286a-4353-9a4f-ddc04bb85a1b)

