### PR TITLE
Added same site cookie into the framework.

### DIFF
--- a/src/HttpContext.php
+++ b/src/HttpContext.php
@@ -90,11 +90,14 @@ class HttpContext extends AppContext
             setcookie(
                 $session['name'],
                 $_COOKIE[$session['name']],
-                time() + $session['lifetime'],
-                $session['path'],
-                $session['domain'],
-                $session['secure'],
-                $session['httponly']
+                [
+                    'expires'  => time() + $session['lifetime'],
+                    'path'     => $session['path'],
+                    'domain'   => $session['domain'],
+                    'secure'   => $session['secure'],
+                    'httponly' => $session['httponly'],
+                    'samesite' => $session['samesite'],
+                ]
             );
         }
         session_start([
@@ -106,6 +109,7 @@ class HttpContext extends AppContext
             'cookie_httponly' => $session['httponly'],
             'cache_limiter'   => '',
             'gc_maxlifetime'  => $session['lifetime'] * 3,
+            'cookie_samesite' => $session['samesite'],
         ]);
     }
 }


### PR DESCRIPTION
https://kelvineducation.atlassian.net/browse/PULSE-529

## What did you change?

🚔 Security

Changed samesite cookie policy to strict.

Note: This will correspond to necessary changes in the framework pull request.
https://github.com/kelvineducation/pulse/pull/1375

## Why did you change it?

As part of the ZAP security scanning, one issue that came up is the lack of anti-csrf tokens.  By adding samesite cookies, the security issue is resolved without the need to add the anti-csrf tokens.  
