### PR TITLE
Framework Select Opt Groups

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,20 +6,20 @@ export GID=$(shell id -g)
 install: build-compose-file ${INSTALL_TARGET}
 
 install-docker:
-	docker-compose build
-	docker-compose up -d
-	docker-compose exec php-fpm composer install
+	docker compose build
+	docker compose up -d
+	docker compose exec php-fpm composer install
 
 install-buoy: install-dev
 
 install-dev: install-docker
 
 tests:
-	docker-compose exec php-fpm ./bin/tests
+	docker compose exec php-fpm ./bin/tests
 
 php-cli:
-	docker-compose exec php-fpm /bin/sh
+	docker compose exec php-fpm /bin/sh
 
 build-compose-file:
 	rm -f docker-stack.yml docker-compose.yml
-	docker-compose -f docker-utils.yml run --rm yaml-merge
+	docker compose -f docker-utils.yml run --rm yaml-merge

--- a/tests/form.phpt
+++ b/tests/form.phpt
@@ -1,6 +1,7 @@
 <?php
 
 use The\Form;
+use The\Form\Field;
 use The\Tests\Test;
 
 test("form addField does not allow duplicate field names", function (Test $t) {
@@ -11,4 +12,71 @@ test("form addField does not allow duplicate field names", function (Test $t) {
     $t->throws(function() use ($form) {
         $form->addText('testing');
     }, '/FormException/');
+});
+
+test("form select html", function (Test $t) {
+  $field = new Field('pizza', 'select', 'Pizza');
+  $html = <<<'HTML'
+    <select id="pizza" name="pizza">
+
+    </select>
+    HTML;
+  $t->equals($field->toHtml(), $html);
+});
+
+test("form select html with options", function (Test $t) {
+  $field = new Field('pizza', 'select', 'Pizza');
+  $field->setOptions(['cheese' => 'Cheese', 'pepperoni' => 'Pepperoni']);
+  $html = <<<'HTML'
+    <select id="pizza" name="pizza">
+    <option value="cheese">Cheese</option>
+
+    <option value="pepperoni">Pepperoni</option>
+
+    </select>
+    HTML;
+  $t->equals($field->toHtml(), $html);
+});
+
+test("form select html with selected options", function (Test $t) {
+  $field = new Field('pizza', 'select', 'Pizza');
+  $field->setOptions(['cheese' => 'Cheese', 'pepperoni' => 'Pepperoni']);
+  $field->setSelected(['pepperoni']);
+  $html = <<<'HTML'
+    <select id="pizza" name="pizza">
+    <option value="cheese">Cheese</option>
+
+    <option value="pepperoni" selected="selected">Pepperoni</option>
+
+    </select>
+    HTML;
+  $t->equals($field->toHtml(), $html);
+});
+
+//create test that tests for opt groups
+test("form select html with selected options", function (Test $t) {
+  $field = new Field('pizza', 'select', 'Pizza');
+  $field->setOptions([
+    'cheese' => 'Cheese',
+    'pepperoni' => 'Pepperoni',
+    'Sausages' => [
+      'sausage1' => 'Sausage 1',
+      'sausage2' => 'Sausage 2'
+    ],
+  ]);
+  $field->setSelected(['pepperoni']);
+
+  $html = <<<'HTML'
+    <select id="pizza" name="pizza">
+    <option value="cheese">Cheese</option>
+
+    <option value="pepperoni" selected="selected">Pepperoni</option>
+    <optgroup label="Sausages">
+    <option value="sausage1">Sausage 1</option>
+    <option value="sausage2">Sausage 2</option>
+    </optgroup>
+
+    </select>
+    HTML;
+  $t->equals($field->toHtml(), $html);
 });


### PR DESCRIPTION
https://kelvineducation.atlassian.net/browse/PULSE-535

## What did you change?

💅 Improvement

Added the ability to add opt groups to drop down selection fields.


## Why did you change it?

In instances in which the selection has a lot of options, adding an opt group provides a nice way to label and organize options for users.

