### PR TITLE
Asset Buster Recursion Refactor

### DIFF
--- a/src/AssetBuster.php
+++ b/src/AssetBuster.php
@@ -92,8 +92,6 @@ class AssetBuster
 
         Debug::echo(sprintf('%s/%s', $dirname, $file->getFilename()));
 
-        $stats = ["unlinked" => 0, "linked" => 0, "skipped" => 0];
-
         // update method to support nested asset directories
         if ($file->isDir() && !$file->isDot()) {
             Debug::echo('recursing');

--- a/src/AssetBuster.php
+++ b/src/AssetBuster.php
@@ -118,8 +118,6 @@ class AssetBuster
             return;
         }
 
-        $this->removeOldSymlink($url);
-
         $sha = sha1_file($file->getPathname());
         if ($sha === false) {
             throw new \Exception(sprintf(
@@ -134,15 +132,12 @@ class AssetBuster
         $link_pathname = $this->public_path . $link_url;
         $relative_target_pathname = '../../' . str_repeat('../', $recursion_level) . $dirname . '/' . $file->getFilename();
 
+        @unlink($link_pathname);
+
         $this->assets[$url] = [
             'sha'   => $sha,
             'url'   => $link_url,
         ];
-
-        if (file_exists($link_pathname)) {
-            Debug::echo(sprintf('skipping existing symlink %s', $link_pathname));
-            return;
-        }
 
         Debug::echo(sprintf('linking %s -> %s', $link_pathname, $relative_target_pathname));
         $symlink = @symlink($relative_target_pathname, $link_pathname);
@@ -165,23 +160,6 @@ class AssetBuster
             return false;
         }
 
-        return true;
-    }
-
-    private function removeOldSymlink(string $url): bool
-    {
-        if (!isset($this->assets[$url])) {
-            return false;
-        }
-
-        $old_symlink_path = $this->public_path . '/' . $this->assets[$url]['url'];
-        $remove_old_symlink = unlink($old_symlink_path);
-        if ($remove_old_symlink === false) {
-            throw new \Exception(sprintf(
-                "Could not remove old symlink **%s**",
-                $old_symlink_path
-            ));
-        }
         return true;
     }
 }


### PR DESCRIPTION
https://kelvineducation.atlassian.net/browse/PULSE-601

*Note:
This pr should be reviewed in conjunction with the following pr in pulse:
https://github.com/kelvineducation/pulse/tree/df-pulse-588

## What did you change?

🐞 Bug
💅 Improvement

Added recursive functionality to asset buster.  Asset buster will not account for files inside of the public/css/lib and public/js/lib directories and create appropriate asset links.

## Why did you change it?
We needed asset buster to iterate through the lib directories.


